### PR TITLE
Sleep trend metric

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+*.swp

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -18,8 +18,17 @@ class DashboardController < ApplicationController
       @response = JSON.parse(res,object_class: OpenStruct)
       # last_month_total_sleep, last_month_sleep_events
       # last_week_total_sleep, last_week_sleep_events
-      @last_week_average_sleep = 9.5
-      @last_month_average_sleep = 8
+
+      @sleep_events = @response.select {|event| event['event_name'] == 'Sleep'}
+      # duration is in milliseconds in the data packet
+      @last_month_total_sleep = @sleep_events.select {|event| event['start_time'].to_datetime > 30.days.ago}.sum {|event| event['parameters']['duration']}/(60*1000)
+      @last_month_sleep_event = @sleep_events.select {|event| event['start_time'].to_datetime > 30.days.ago}.size
+      @last_week_total_sleep = @sleep_events.select {|event| event['start_time'].to_datetime > 7.days.ago}.sum {|event| event['parameters']['duration']}/(60*1000)
+      @last_week_sleep_event = @sleep_events.select {|event| event['start_time'].to_datetime > 7.days.ago}.size
+      
+      @last_week_average_sleep = @last_week_sleep_event>0? @last_week_total_sleep/@last_week_sleep_event:0
+      @last_month_average_sleep = @last_month_sleep_event>0? @last_month_total_sleep/@last_month_sleep_event:0
+      
     end
     
   end

--- a/app/views/pages/dashboard/_metrics_summary.html.erb
+++ b/app/views/pages/dashboard/_metrics_summary.html.erb
@@ -6,8 +6,12 @@
         <div class="row">
           <div class="col">
             <h5 class="card-title text-uppercase text-muted mb-0">Average sleep</h5>
-            
-            <span class="h2 font-weight-bold mb-0"><%=avg_sleep_week%></span>
+            <%if avg_sleep_week == 0%>
+            <%sleep_text = "No events found"%>
+            <%else%>
+            <%sleep_text = "#{avg_sleep_week/60} h #{avg_sleep_week%60} m"%>
+            <%end%>
+            <span class="h2 font-weight-bold mb-0"><%=sleep_text%></span>
           </div>
           <div class="col-auto">
             <div class="icon icon-shape bg-gradient-red text-white rounded-circle shadow">


### PR DESCRIPTION
The sleep trend metric in the main dashboard page is now being calculated using events data from the API call.

We compare the average sleep duration in last one week with that for last one month, and display the results.