### PR TITLE
Bug fix in sleep duration distribution comparison chart

### DIFF
--- a/app/controllers/sleep_controller.rb
+++ b/app/controllers/sleep_controller.rb
@@ -68,7 +68,9 @@ class SleepController < ApplicationController
         exercise_days = (run_days | bike_days)
         @exercise_days_sleep = []
         exercise_days.each do |d|
-            @exercise_days_sleep = @exercise_days_sleep.append(((@daily_sleep_summary[d]['duration']*60).to_i / sleep_window)*sleep_window)
+            if @daily_sleep_summary.key?(d)
+                @exercise_days_sleep = @exercise_days_sleep.append(((@daily_sleep_summary[d]['duration']*60).to_i / sleep_window)*sleep_window)
+            end
         end
         @exercise_days_sleep = @exercise_days_sleep.select{|v| v>0}
         @exercise_sleep_count = {}


### PR DESCRIPTION
The application was giving an error if there was an exercise event beyond the date range of sleep events. Fixed it by adding a condition to check if the exercise event has a corresponding sleep value or not.