### PR TITLE
Personicle web dashboard: dashboard page information blurbs and metric summary alignment

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -51,9 +51,29 @@
 @import 'custom/utilities';
 @import 'custom/vendors';
 @import "bootstrap/scss/bootstrap";
-// body { 
-//     background-color: #5e72e4;
-// }
+
+.widget-container {
+  display: grid;
+  overflow: hidden;
+  grid-template-columns: repeat(1, 1fr);
+  grid-auto-rows: 1fr;
+  grid-column-gap: 5px;
+  grid-row-gap: 5px;
+  max-width: 100%;
+}
+
+.widget-wrap {
+  display: flex;
+  padding: 0.5em;
+  margin-bottom: 20px;
+}
+
+.widget-card {
+  width: 100%;
+
+}
+
+
 
 .physician-questions-error-message, .user-physician-responses-error-message {
   background-color: rgb(177, 20, 20);
@@ -74,13 +94,13 @@
     margin: 0px;
     padding: 0px;
 .header-info {
-    border-radius: 25px;
+    border-radius: 2.5rem;
     background-color: white;
     color: black;
-    padding: 30px 0px 30px 20px;
-    margin: 0px 25px 0px 25px;
+    padding: 2rem 1.5rem 1.6rem 1.5rem;
+    margin: 0rem 1.5rem 0rem 1.5rem;
     text-size-adjust: auto;
-    height: 175px;
+    height: 12rem auto;
 }
 }
 
@@ -111,4 +131,3 @@
     opacity: 1;
     visibility: visible;
   }
-

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -77,9 +77,10 @@
     border-radius: 25px;
     background-color: white;
     color: black;
-    padding: 20px 15px;
-    margin: 0px 25px;
-    height: 150px;
+    padding: 20px 15px 20px 15px;
+    margin: 0px 25px 0px 25px;
+    text-size-adjust: auto;
+    height: 175px;
 }
 }
 .hovertext {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -77,12 +77,13 @@
     border-radius: 25px;
     background-color: white;
     color: black;
-    padding: 20px 15px 20px 15px;
+    padding: 30px 0px 30px 20px;
     margin: 0px 25px 0px 25px;
     text-size-adjust: auto;
     height: 175px;
 }
 }
+
 .hovertext {
     position: relative;
     // font-family:

--- a/app/views/pages/_sidenav.html.erb
+++ b/app/views/pages/_sidenav.html.erb
@@ -72,12 +72,12 @@
             </a>
           </li>
           <% end %>
-          <li class="nav-item">
-            <a class="nav-link" href="<%= pages_login_path %>">
-              <i class="ni ni-key-25 text-info"></i>
-              <span class="nav-link-text">Login</span>
-            </a>
-          </li>
+          <%# <li class="nav-item">
+            <a class="nav-link" href="<%= pages_login_path %><%# "> %>
+              <%# <i class="ni ni-key-25 text-info"></i> %>
+              <%# <span class="nav-link-text">Login</span> %>
+            <%# </a> %>
+          <%# </li> %>
           <% if session[:oktastate]["physician"]%>
           <li class="nav-item">
             <a class="nav-link" href=<%= pages_dashboard_physician_path %> >

--- a/app/views/pages/dashboard/_metrics_summary.html.erb
+++ b/app/views/pages/dashboard/_metrics_summary.html.erb
@@ -4,10 +4,10 @@
     
 
 <div class="row">
-  <div class="col-xl-4 col-md-6">
-    <div class="card card-stats">
+  <div class="widget-container col-xl-4 col-md-6">
+    <div class="widget-wrap card card-stats">
       <!-- Card body -->
-      <div class="card-body">
+      <div class="widget-card card-body">
         <div class="row">
           <div class="col">  
             <h5 class="card-title text-uppercase text-muted mb-0"><span class="hovertext" data-hover="The average sleep of the user over the course of the month. Indicates increase or decrease in sleep as compared to the previous month."><i class="fa fa-info-circle" aria-hidden="true"></i></span> Average sleep </h5>
@@ -45,11 +45,11 @@
     </div>
   </div>
 
-  <div class="col-xl-4 col-md-6">
+  <div class="widget-container col-xl-4 col-md-6">
 
-    <div class="card card-stats">
+    <div class="widget-wrap card card-stats">
       <!-- Card body -->
-      <div class="card-body">
+      <div class="widget-card card-body">
         <div class="row">
           <div class="col">
             <h5 class="card-title text-uppercase text-muted mb-0"><span class="hovertext" data-hover="The average calories burned by the user over the course of the month. Indicates increase or decrease in calories burned as compared to the previous month."><i class="fa fa-info-circle" aria-hidden="true"></i></span> Calories Burned</h5>
@@ -85,11 +85,11 @@
     </div>
   </div>
 
-  <div class="col-xl-4 col-md-6">
+  <div class="widget-container col-xl-4 col-md-6">
 
-    <div class="card card-stats">
+    <div class="widget-wrap card card-stats">
       <!-- Card body -->
-      <div class="card-body">
+      <div class="widget-card card-body">
         <div class="row">
           <div class="col">
             <h5 class="card-title text-uppercase text-muted mb-0"><span class="hovertext" data-hover="The number of steps over the past month performing physical activity. Indicates increase or decrease in steps as compared to the previous month."><i class="fa fa-info-circle" aria-hidden="true"></i></span> Walking </h5>

--- a/app/views/pages/dashboard/_metrics_summary.html.erb
+++ b/app/views/pages/dashboard/_metrics_summary.html.erb
@@ -56,7 +56,7 @@
             <%if avg_calories_week == 0%>
             <%calories_text = "No calories data"%>
             <%else%>
-            <%calories_text = "#{number_with_delimiter(avg_calories_week, :delimiter => ',')} calories per day"%>
+            <%calories_text = "#{number_with_delimiter(avg_calories_week.round(2), :delimiter => ',')} calories per day"%>
             <%end%>
             <span class="h2 font-weight-bold mb-0"><%=calories_text%></span>
           </div>
@@ -85,7 +85,7 @@
     </div>
   </div>
 
-  <div class="col-xl-3 col-md-6">
+  <div class="col-xl-4 col-md-6">
 
     <div class="card card-stats">
       <!-- Card body -->

--- a/app/views/pages/dashboard/_metrics_summary.html.erb
+++ b/app/views/pages/dashboard/_metrics_summary.html.erb
@@ -52,7 +52,7 @@
       <div class="card-body">
         <div class="row">
           <div class="col">
-            <h5 class="card-title text-uppercase text-muted mb-0">Calories Burned</h5>
+            <h5 class="card-title text-uppercase text-muted mb-0"><span class="hovertext" data-hover="The average calories burned by the user over the course of the month. Indicates increase or decrease in calories burned as compared to the previous month."><i class="fa fa-info-circle" aria-hidden="true"></i></span> Calories Burned</h5>
             <%if avg_calories_week == 0%>
             <%calories_text = "No calories data"%>
             <%else%>


### PR DESCRIPTION
- Personicle web dashboard: dashboard page information blurbs and metric summary alignment: Widgets in same row automatically take on height of tallest widget. 
- Information header division resizes with resizing text on window resize or zoom in/zoom out of page: https://github.com/ClearsenseData/personicle-rails/issues/185
- Login Page removed from side navigation bar: https://github.com/ClearsenseData/personicle-rails/issues/144